### PR TITLE
feat(network): read iface speed from sys first

### DIFF
--- a/network.go
+++ b/network.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -98,6 +99,22 @@ func getSupported(name string) uint32 {
 	return 0
 }
 
+// readIfaceSpeed reads /sys/class/net/<iface>/speed
+// inspired by https://github.com/prometheus/procfs/blob/master/sysfs/net_class.go#L56
+func readIfaceSpeed(file string) (speed uint) {
+	f, err := os.Open(file)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	if b, err := ioutil.ReadAll(f); err == nil {
+		if s, err := strconv.Atoi(strings.TrimSpace(string(b))); err == nil && s > 0 {
+			speed = uint(s)
+		}
+	}
+	return
+}
+
 func (si *SysInfo) getNetworkInfo() {
 	sysClassNet := "/sys/class/net"
 	devices, err := ioutil.ReadDir(sysClassNet)
@@ -123,12 +140,17 @@ func (si *SysInfo) getNetworkInfo() {
 		inet, _ := net.InterfaceByName(link.Name())
 		ip_addrs, _ := getIPAddrByInterface(inet)
 
+		speed := readIfaceSpeed(path.Join(fullpath, "speed"))
+		if speed == 0 {
+			speed = getMaxSpeed(supp)
+		}
+
 		device := NetworkDevice{
 			Name:       link.Name(),
 			MACAddress: slurpFile(path.Join(fullpath, "address")),
 			IPAddress:  ip_addrs,
 			Port:       getPortType(supp),
-			Speed:      getMaxSpeed(supp),
+			Speed:      speed,
 			MTU:        inet.MTU,
 		}
 


### PR DESCRIPTION
The `ioctl` seems not to work for virtual interfaces, so the interface speed and port-type are missing.
In Prometheus's node_exporter's collecting, it reads the system file `/sys/class/net/<iface>/speed` directly, so I think we can do the same.

before:


```bash
./sysinfo

    {
      "name": "enp4s0",
      "driver": "r8169",
      "macaddress": "00:e0:4c:d6:0b:af",
      "ipaddress": [
        "192.168.1.81/24",
      ],
      "port": "tp/mii",
      "speed": 1000,
      "mtu": 1500
    },
    {
      "name": "veth19633b8",
      "macaddress": "9a:e3:c8:b6:ac:8f",
      "ipaddress": [
        "fe80::98e3:c8ff:feb6:ac8f/64"
      ],
      "mtu": 1500
    },
 ...
```

after:

```bash
./sysinfo

    {
      "name": "enp4s0",
      "driver": "r8169",
      "macaddress": "00:e0:4c:d6:0b:af",
      "ipaddress": [
        "192.168.1.81/24",
        "fe80::2e0:4cff:fed6:baf/64"
      ],
      "port": "tp/mii",
      "speed": 1000,
      "mtu": 1500
    },
    {
      "name": "veth19633b8",
      "macaddress": "9a:e3:c8:b6:ac:8f",
      "ipaddress": [
        "fe80::98e3:c8ff:feb6:ac8f/64"
      ],
      "speed": 10000,
      "mtu": 1500
    },
 ...
```