### PR TITLE
Add FreeBSD support

### DIFF
--- a/kernel.go
+++ b/kernel.go
@@ -1,6 +1,9 @@
 // Copyright © 2016 Zlatko Čalušić
 //
 // Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+//
+//go:build !freebsd
+// +build !freebsd
 
 package sysinfo
 

--- a/kernel_freebsd.go
+++ b/kernel_freebsd.go
@@ -1,0 +1,42 @@
+// Copyright © 2016 Zlatko Čalušić
+//
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+//
+//go:build freebsd
+// +build freebsd
+
+package sysinfo
+
+import (
+	"encoding/binary"
+	"strconv"
+	"syscall"
+)
+
+// Kernel information.
+type Kernel struct {
+	Release      string `json:"release,omitempty"`
+	Version      string `json:"version,omitempty"`
+	Architecture string `json:"architecture,omitempty"`
+}
+
+func (si *SysInfo) getKernelInfo() {
+	osrel, err := syscall.Sysctl("kern.osrelease")
+	if err != nil {
+		return
+	}
+	si.Kernel.Release = osrel
+
+	osver, err := syscall.Sysctl("kern.osrevision")
+	if err != nil {
+		return
+	}
+	osverInt := uint64(binary.LittleEndian.Uint32(append([]byte(osver), 0x0)))
+	si.Kernel.Version = strconv.FormatUint(osverInt, 10)
+
+	osarch, err := syscall.Sysctl("hw.machine_arch")
+	if err != nil {
+		return
+	}
+	si.Kernel.Architecture = osarch
+}


### PR DESCRIPTION
This fixes this:
```
% go build
./kernel.go:24:12: undefined: syscall.Utsname
./kernel.go:25:12: undefined: syscall.Uname
```

With this PR:
```
% sudo go run cmd/sysinfo/main.go | jq ".kernel"
{
  "release": "13.0-RELEASE",
  "version": "199506",
  "architecture": "amd64"
}
```

`sysctl` info:

```
% sysctl kern.ostype
kern.ostype: FreeBSD
% sysctl kern.osrelease
kern.osrelease: 13.0-RELEASE
% sysctl kern.osrevision
kern.osrevision: 199506
% sysctl kern.version
kern.version: FreeBSD 13.0-RELEASE #0 releng/13.0-n244733-ea31abc261f: Fri Apr  9 04:24:09 UTC 2021
    root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC

% sysctl kern.osreldate
kern.osreldate: 1300139
% sysctl hw.machine
hw.machine: amd64
% sysctl hw.machine_arch
hw.machine_arch: amd64
```

`uname` and `freebsd-version` info:

```
% uname -o
FreeBSD
% uname -r
13.0-RELEASE
% uname -v
FreeBSD 13.0-RELEASE #0 releng/13.0-n244733-ea31abc261f: Fri Apr  9 04:24:09 UTC 2021     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC
% uname -p
amd64
% uname -U
1300139
% freebsd-version
13.0-RELEASE-p5
```